### PR TITLE
many improvements to "Get-BitLockerInfo.ps1"

### DIFF
--- a/Get-BitLockerInfo.ps1
+++ b/Get-BitLockerInfo.ps1
@@ -1,53 +1,37 @@
-# requires c:\pstools\psexec.exe
+# requires psexec
 
 function Get-BitLockerInfo {
     param (
-        $ComputerName = $env:COMPUTERNAME
+        [string]$ComputerName = $env:COMPUTERNAME,
+        [string]$PsExecPath = 'C:\pstools\psexec.exe'
     )
-    
-    $comp = [pscustomobject]@{
-        Name = $ComputerName
-        OS = Get-Os $ComputerName
-    }
 
-    $comp = $comp | select *,
-        @{n='User';e={''}},
-        @{n='BitLocker Drive Encryption';e={''}},
-        @{n='BitLocker Version';e={''}},
-        @{n='Conversion Status';e={''}},
-        @{n='Encryption Method';e={''}},
-        @{n='Identification Field';e={''}},
-        @{n='Key Protectors';e={''}},
-        @{n='Lock Status';e={''}},
-        @{n='Percentage Encrypted';e={''}},
-        @{n='Protection Status';e={''}},
-        @{n='Size';e={''}},
-        @{n='Volume C';e={''}}
-
-    # manage-bde -status c: -computername $comp.name # can't use because of the context it says manage-bde not found
-    $bitlockerinfo = (c:\pstools\PsExec.exe \\$($comp.name) manage-bde -status c:).Split("`n").trim() | ? {$_ -and $_ -notmatch '^(\s+)?$'}
-    $hash = @{}
-    $bitlockerinfo | ? {$_ -match '[a-z]:\s'} | % {
-        $split = $_.split(':').trim()
-        if ($split[0] -match '^volume') {
-            $split[1] = $bitlockerinfo[$bitlockerinfo.indexof($_) + 1]
+    # Test connectivity before attempting to connect
+    if (Test-Connection -ComputerName $ComputerName -Quiet -Count 2) {
+        try{
+            $user = (Get-WmiObject -Class Win32_ComputerSystem -ComputerName $ComputerName ).UserName
         }
-        $hash.add($split[0], $split[1])
+        catch {
+            $user = 'UNKNOWN'
+        }
+
+        $hash = [ordered]@{
+            'ComputerName' = $ComputerName
+            'User'         = $user
+        }
+
+        # manage-bde -status c: -computername $comp.name # can't use because of the context it says manage-bde not found
+        # With this parsing of the output of 'manage-bde' we ensure it works on systems using languages other than English, and it's more robust and efficient in general
+        $bitlockerinfo = (& $PsExecPath \\$ComputerName manage-bde -status c:) -replace ':','=' | Where-Object { $_ -match "^(\s{4})" } | ConvertFrom-StringData
+        
+        foreach ($key in $bitlockerinfo.Keys) {
+            $hash.Add("$key", $bitlockerinfo."$key")
+        }
+
+        # return the created object
+        [PSCustomObject]$hash
+
+    } else {
+        Write-Error "Could not reach target computer: '$ComputerName'."
     }
-    $bitlockerinfo = [pscustomobject]$hash
-
-    $comp.User = Get-User $comp.name
-    $comp.'BitLocker Drive Encryption' = $bitlockerinfo.'BitLocker Drive Encryption'
-    $comp.'BitLocker Version' = $bitlockerinfo.'BitLocker Version'
-    $comp.'Conversion Status' = $bitlockerinfo.'Conversion Status'
-    $comp.'Encryption Method' = $bitlockerinfo.'Encryption Method'
-    $comp.'Identification Field' = $bitlockerinfo.'Identification Field'
-    $comp.'Key Protectors' = $bitlockerinfo.'Key Protectors'
-    $comp.'Lock Status' = $bitlockerinfo.'Lock Status'
-    $comp.'Percentage Encrypted' = $bitlockerinfo.'Percentage Encrypted'
-    $comp.'Protection Status' = $bitlockerinfo.'Protection Status'
-    $comp.Size = $bitlockerinfo.Size
-    $comp.'Volume C' = $bitlockerinfo.'Volume C'
-
-    $comp
 }


### PR DESCRIPTION
Hi, I really liked your script "Get-BitLockerInfo.ps1" and saw some opportunities for improvements too!

- You can now specify an alternative path to psexec if needed
- Test connection to target computer before trying to query it (fails faster now if target is offline)
- Parsing of the output of `manage-bde` is now more robust, simplified and works in Windows languages other than english (tested in German here, works!)
- Should be faster overall too, relevant if you ever try to query many machines at once

I hope the changes are welcome, if you have any questions just ask before merging!